### PR TITLE
Add find_executable functions

### DIFF
--- a/process-lib/examples/script.ml
+++ b/process-lib/examples/script.ml
@@ -1,5 +1,7 @@
-#!/usr/bin/env ocaml -noinit -w +a
+#!/usr/bin/env ocaml
+(* TODO: pass -noinit to ocaml toplevel *)
 #use "topfind"
+#warnings "+a"
 #thread
 (* #require "ppx_jane,core" *)
 #require "shexp.process"

--- a/process-lib/examples/script.ml
+++ b/process-lib/examples/script.ml
@@ -8,11 +8,9 @@ open Shexp_process
 open Shexp_process.Infix
 (* open Core *)
 
-(* Check if cmd is in PATH *)
-let command (cmd: string) : bool t =
-  run_exit_code "command" ["-v"; cmd]
-  |> outputs_to "/dev/null"
-  >>| fun code -> code = 0
+(* Check if exe is in PATH *)
+let command (exe: string) : bool t =
+  find_executable exe >>| fun exe -> exe <> None
 
 (* Finds all files with the given extension in the git repo (or subdirs) *)
 let find_files ~(ext: string) : unit t =

--- a/process-lib/src/env.mli
+++ b/process-lib/src/env.mli
@@ -32,6 +32,7 @@ val add_cwd_ref : t -> unit
 val deref_cwd : t -> unit
 
 (** Unix environment *)
+val find_executable : t -> string -> string option
 val get_env : t -> string -> string option
 val set_env : t -> string -> string -> t
 val unset_env : t -> string -> t

--- a/process-lib/src/process.ml
+++ b/process-lib/src/process.ml
@@ -657,6 +657,20 @@ let run_bool ?(true_v=[0]) ?(false_v=[1]) prog args =
     Printf.ksprintf failwith "Command exited with unexpected code %d: %s"
       code (cmd_line prog args)
 
+let find_executable =
+  let prim =
+    Prim.make "find-executable"
+      [A sexp_of_string]
+      (F (sexp_of_option sexp_of_string))
+      Env.find_executable
+  in
+  fun exe -> pack1 prim exe
+
+let find_executable_exn exe =
+  find_executable exe >>| function
+  | None -> Printf.ksprintf failwith "command %S not found" exe
+  | Some x -> x
+
 let get_env =
   let prim =
     Prim.make "get-env"

--- a/process-lib/src/process.mli
+++ b/process-lib/src/process.mli
@@ -205,6 +205,10 @@ val wait : Background_command.t -> Exit_status.t t
 
 (** {1 Unix environment} *)
 
+(** Return the absolute path to the given command. *)
+val find_executable : string -> string option t
+val find_executable_exn : string -> string t
+
 (** Return the value associated to the given environment variable. *)
 val get_env : string -> string option t
 val get_env_exn : string -> string t


### PR DESCRIPTION
Also fixes a few portability issues in the example script as mentioned in #5.