### PR TITLE
add call_xxx and backquote functions

### DIFF
--- a/process-lib/src/jbuild
+++ b/process-lib/src/jbuild
@@ -3,7 +3,8 @@
   (public_name shexp.process)
   ;; No deps outside of the compiler distribution!
 (flags (:standard -safe-string))
-  (libraries (unix
+  (libraries (base
+              unix
               threads
               spawn
               shexp_sexp

--- a/process-lib/src/process.ml
+++ b/process-lib/src/process.ml
@@ -1242,7 +1242,7 @@ let backquote =
   let cmd prog args = command "backquote" prog args in
   fun ?context fmt ->
     let f prog args =
-      eval ?context (pipe (cmd prog args) read_all)
+      eval ?context (capture_unit [Stdout] (cmd prog args))
     in
     generic_call ~f fmt
 

--- a/process-lib/src/process.ml
+++ b/process-lib/src/process.ml
@@ -675,19 +675,73 @@ let run =
 
 let run_bool =
   let cmd = command_bool "run" in
-  fun ?(true_v=[0]) ?(false_v=[1]) prog args -> cmd ~true_v ~false_v prog args 
+  fun ?(true_v=[0]) ?(false_v=[1]) prog args -> cmd ~true_v ~false_v prog args
 
+(* Function that parses a string into a list of command arguments. The function
+   splits on blanks but blanks are preserved when inside a single- or
+   double-quoted string. Escaping is not taken into account, meaning backslashes
+   in double-quoted strings are considered as any character.
+
+   The function works by filling a stack of already recognized "items" (called
+   program as well as its arguments) as well a current item that is under
+   recognition. Due to the nature of the algorithm, the list of items is
+   reversed and the items themselves too, so everything is reversed in one
+   stroke at th end. *)
+let parse_command =
+  let open Base in
+  let double = '"' in
+  let single = Char.of_string "'" in
+  let push elt stack = match elt with
+    | [] -> stack
+    | _ -> elt :: stack
+  in
+  let rec parse cmd len items current i =
+    if i >= len then            (* done *)
+      push current items
+    else
+      let c = String.get cmd i in
+      if Char.equal c single then
+        parse_single cmd len (push current items) [] (i + 1)
+      else if Char.equal c double then
+        parse_double cmd len (push current items) [] (i + 1)
+      else if Char.is_whitespace c then
+        parse cmd len (push current items) [] (i + 1)
+      else                      (* any other, incl. \ *)
+        parse cmd len items (c :: current) (i + 1)
+  and parse_double cmd len items current i =
+    if i >= len then         
+      Printf.ksprintf failwith "Called command is badly formed: %S" cmd
+    else
+      let c = String.get cmd i in
+      if Char.equal c double then
+        parse cmd len (push current items) [] (i + 1)
+      else
+        parse_double cmd len items (c :: current) (i + 1)
+  and parse_single cmd len items current i =
+    if i >= len then         
+      Printf.ksprintf failwith "Called command is badly formed: %S" cmd
+    else
+      let c = String.get cmd i in
+      if Char.equal c single then
+        parse cmd len (push current items) [] (i + 1)
+      else
+        parse_single cmd len items (c :: current) (i + 1)
+  in
+  fun cmd_string ->
+    parse cmd_string (String.length cmd_string) [] [] 0
+    |> List.rev_map ~f:(fun item -> List.rev item |> String.of_char_list)
+    
 (* generic function that interprets the format string, splits into and
    then produces a call to a 'run' function (as defined above). *)
 let generic_call ~f fmt =
-  let get_prog_args cmd_string = 
-    let strings = (* split into a list that may contain spurious empty strings that we remove *)
-      Base.String.split_on_chars cmd_string ~on:[' '; '\t'; '\n'; '\r'] 
-      |> Base.List.concat_map ~f:(function "" -> [] | s -> [s])
-    in
+  let get_prog_args cmd_string =
+    (* split into a list that may contain spurious empty strings that we remove
+       *)
+    let strings = parse_command cmd_string in
     match strings with
     | [] ->
-      Printf.ksprintf failwith "Called command resolves to empty string: %S" cmd_string
+        Printf.ksprintf
+          failwith "Called command resolves to empty string: %S" cmd_string
     | prog::args -> f prog args
   in
   Printf.ksprintf get_prog_args fmt

--- a/process-lib/src/process.ml
+++ b/process-lib/src/process.ml
@@ -617,90 +617,80 @@ let wait =
   in
   fun bc -> pack1 prim bc
 
-(* [command_xxx] functions are only auxiliary functions to be used to
-   create [run_xxx] and [call_xxx] functions; the first argument is the
-   name of the function for tracing purpose. *)
+(* [command_xxx] functions are only auxiliary functions to be used to create
+   [run_xxx] and [call_xxx] functions; [C.cmd] is the name of the function for
+   tracing purpose. *)
+module MakeCommands (C : sig val cmd : string end) = struct
+  (* This could be implemented in term of [spawn] followed by a [wait], but
+     doing it in one primitive improve traces. *)
+  let command_exit_status =
+    let prim =
+      Prim.make C.cmd
+        [ A sexp_of_string
+        ; A (sexp_of_list sexp_of_string)
+        ]
+        (F Exit_status.sexp_of_t)
+        (fun env prog args ->
+           match Env.spawn env ~prog ~args with
+             | Ok pid -> waitpid pid
+             | Error Command_not_found ->
+                 Printf.ksprintf failwith "%s: command not found"
+                   (quote_for_errors prog))
+    in
+    fun prog args -> pack2 prim prog args
 
-(* This could be implemented in term of [spawn] followed by a [wait], but doing it in one
-   primitive improve traces. *)
-let command_exit_status cmd_string =
-  let prim =
-    Prim.make cmd_string
-      [ A sexp_of_string
-      ; A (sexp_of_list sexp_of_string)
-      ]
-      (F Exit_status.sexp_of_t)
-      (fun env prog args ->
-         match Env.spawn env ~prog ~args with
-         | Ok pid -> waitpid pid
-         | Error Command_not_found ->
-           Printf.ksprintf failwith "%s: command not found" (quote_for_errors prog))
-  in
-  fun prog args -> pack2 prim prog args
+  let command_exit_code prog args =
+    command_exit_status prog args >>| function
+    | Exited n -> n
+    | Signaled signal ->
+        Printf.ksprintf failwith "Command got signal %d: %s"
+          signal (cmd_line prog args)
+
+  let command prog args =
+    command_exit_code prog args >>| fun code ->
+    if code <> 0 then
+      Printf.ksprintf failwith "Command exited with code %d: %s"
+        code (cmd_line prog args)
+
+  let command_bool ?(true_v=[0]) ?(false_v=[1]) prog args =
+    command_exit_code prog args >>| fun code ->
+    if List.mem code ~set:true_v then
+      true
+    else if List.mem code ~set:false_v then
+      false
+    else
+      Printf.ksprintf failwith "Command exited with unexpected code %d: %s"
+        code (cmd_line prog args)
+end
+
+module RunCommands = MakeCommands(struct let cmd = "run" end)
+
+let run_exit_status = RunCommands.command_exit_status
     
-let command_exit_code cmd_string prog args =
-  command_exit_status cmd_string prog args >>| function
-  | Exited n -> n
-  | Signaled signal ->
-    Printf.ksprintf failwith "Command got signal %d: %s"
-      signal (cmd_line prog args)
+let run_exit_code = RunCommands.command_exit_code
 
-let command cmd_string prog args =
-  command_exit_code cmd_string prog args >>| fun code ->
-  if code <> 0 then
-    Printf.ksprintf failwith "Command exited with code %d: %s"
-      code (cmd_line prog args)
+let run = RunCommands.command
 
-let command_bool cmd_string ?(true_v=[0]) ?(false_v=[1]) prog args =
-  command_exit_code cmd_string prog args >>| fun code ->
-  if List.mem code ~set:true_v then
-    true
-  else if List.mem code ~set:false_v then
-    false
-  else
-    Printf.ksprintf failwith "Command exited with unexpected code %d: %s"
-      code (cmd_line prog args)
+let run_bool = RunCommands.command_bool
 
-let run_exit_status =
-  let cmd = command_exit_status "run" in
-  fun prog args -> cmd prog args
+module CallCommands = MakeCommands(struct let cmd = "call" end)
+
+let call_exit_status = function
+  | [] -> failwith "call_exit_status: empty command"
+  | prog::args -> CallCommands.command_exit_status prog args
     
-let run_exit_code =
-  let cmd = command_exit_code "run" in
-  fun prog args -> cmd prog args
+let call_exit_code = function
+  | [] -> failwith "call_exit_code: empty command"
+  | prog::args -> CallCommands.command_exit_code prog args
 
-let run =
-  let cmd = command "run" in
-  fun prog args -> cmd prog args
+let call = function
+  | [] -> failwith "call: empty command"
+  | prog::args -> CallCommands.command prog args
 
-let run_bool =
-  let cmd = command_bool "run" in
-  fun ?(true_v=[0]) ?(false_v=[1]) prog args -> cmd ~true_v ~false_v prog args
+let call_bool ?true_v ?false_v = function
+  | [] -> failwith "call_bool: empty command"
+  | prog::args -> CallCommands.command_bool ?true_v ?false_v prog args
                      
-let call_exit_status =
-  let cmd = command_exit_status "call" in
-  function
-    | [] -> failwith "call_exit_status: empty command"
-    | prog::args -> cmd prog args
-                      
-let call_exit_code =
-  let cmd = command_exit_code "call" in
-  function
-    | [] -> failwith "call_exit_code: empty command"
-    | prog::args -> cmd prog args
-    
-let call_bool =
-  let cmd = command_bool "call" in
-  fun ?(true_v=[0]) ?(false_v=[1]) -> function  
-    | [] -> failwith "call_bool: empty command"
-    | prog::args -> cmd ~true_v ~false_v prog args
-                                                  
-let call =
-  let cmd = command "call" in
-  function
-    | [] -> failwith "call: empty command"
-    | prog::args -> cmd prog args
-
       
 let find_executable =
   let prim =

--- a/process-lib/src/process.ml
+++ b/process-lib/src/process.ml
@@ -1238,14 +1238,6 @@ let sleep =
   in
   fun d -> pack1 prim d
 
-let backquote =
-  let cmd prog args = command "backquote" prog args in
-  fun ?context fmt ->
-    let f prog args =
-      eval ?context (capture_unit [Stdout] (cmd prog args))
-    in
-    generic_call ~f fmt
-
 module Infix = struct
   include Infix0
 

--- a/process-lib/src/process.mli
+++ b/process-lib/src/process.mli
@@ -190,6 +190,36 @@ val run_bool
   -> string list
   -> bool t
 
+
+(** Same functions as the 'run' ones above, but take a format string
+    instead (advice: use quoted strings [{|...|}] to avoid escaping).
+
+    E.g. [call {|grep -i %s %s|} pattern filename] is equivalent to
+    [run "grep" ["-i"; pattern; filename]] *)
+val call : ('a, unit, string, unit t) format4 -> 'a
+val call_exit_code : ('a, unit, string, int t) format4 -> 'a
+val call_exit_status
+  : ('a, unit, string, Exit_status.t t) format4
+  -> 'a
+val call_bool
+  : ?true_v:int list
+  -> ?false_v:int list
+  -> ('a, unit, string, bool t) format4
+  -> 'a
+
+(** Like backquotes in Bash: [backquote fmt] is equivalent to [eval
+    (call fmt |- read_all)]. 
+
+    If [context] is not specified, a temporary one is created. If you
+    are calling [backquote] many times, then creating a context and
+    reusing it is more efficient. *)
+val backquote
+  : ?context:Context.t
+  -> ('a, unit, string, string) format4
+  -> 'a
+
+
+
 module Background_command : sig
   type t
 

--- a/process-lib/src/process.mli
+++ b/process-lib/src/process.mli
@@ -191,21 +191,22 @@ val run_bool
   -> bool t
 
 
-(** Same functions as the 'run' ones above, but take a format string
-    instead (advice: use quoted strings [{|...|}] to avoid escaping).
+(** Same functions as the 'run' ones above, but take a string list instead. This
+   way, the first element and the others are treated in a homogeneous way. It
+   can ease prepending commands in specific circumstances, e.g.  
+    [if profile then call ("time" :: command) else call command]
 
-    E.g. [call {|grep -i %s %s|} pattern filename] is equivalent to
-    [run "grep" ["-i"; pattern; filename]] *)
-val call : ('a, unit, string, unit t) format4 -> 'a
-val call_exit_code : ('a, unit, string, int t) format4 -> 'a
-val call_exit_status
-  : ('a, unit, string, Exit_status.t t) format4
-  -> 'a
+    E.g. [call ["grep"; "-i"; pattern filename]] is equivalent to [run "grep"
+   ["-i"; pattern; filename]] *)
+val call : string list -> unit t
+val call_exit_code : string list -> int t
+val call_exit_status : string list -> Exit_status.t t
 val call_bool
-  : ?true_v:int list
+  :  ?true_v:int list
   -> ?false_v:int list
-  -> ('a, unit, string, bool t) format4
-  -> 'a
+  -> string list
+  -> bool t
+
 
 module Background_command : sig
   type t

--- a/process-lib/src/process.mli
+++ b/process-lib/src/process.mli
@@ -207,19 +207,6 @@ val call_bool
   -> ('a, unit, string, bool t) format4
   -> 'a
 
-(** Like backquotes in Bash: [backquote fmt] is equivalent to [eval
-    (call fmt |- read_all)]. 
-
-    If [context] is not specified, a temporary one is created. If you
-    are calling [backquote] many times, then creating a context and
-    reusing it is more efficient. *)
-val backquote
-  : ?context:Context.t
-  -> ('a, unit, string, string) format4
-  -> 'a
-
-
-
 module Background_command : sig
   type t
 


### PR DESCRIPTION
Related to #7 .
OK so I added `call_xxx` functions corresponding to the previous `run_xxx` ones. As all these `run_xxx` and `call_xxx` functions work in the same way, I factored their code out so as to pass them an argument for tracing purpose (containing `"run"` or `"call"` depending on the function).

I also added a `backquote` function as discussed in #7 .

I don't know the testing means (JS ppx'es) practically nor how to call them from Dune... but I can add some if you give me some indication.

Finally, I rely on Base to parce and split the string passed as a format, so I relied on Base and added it as a dependency to the `jbuild` file. I thought it was ok as Base is already a dependency in the opam file.