### PR TITLE
MSVC compilation and runtime fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,4 +3,4 @@
 - Add `Process.call_xxx` functions that are equivalent to their
   `Process.run_xxx` counterpart except that they take a single string
   list as argument (#8, David Chemouil)
-- Fix MSVC compilation errors (#15, Jonah Beckford)
+- Fix MSVC compilation and runtime errors (#15, Jonah Beckford)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,4 @@
 - Add `Process.call_xxx` functions that are equivalent to their
   `Process.run_xxx` counterpart except that they take a single string
   list as argument (#8, David Chemouil)
+- Fix MSVC compilation errors (#15, Jonah Beckford)

--- a/bigstring-io-lib/src/bigstring_io_stubs.c
+++ b/bigstring-io-lib/src/bigstring_io_stubs.c
@@ -5,6 +5,10 @@
 #include <caml/bigarray.h>
 #include <caml/signals.h>
 #include <caml/unixsupport.h>
+#ifdef _MSC_VER
+/* Link with the ws2_32 WinSock library so that send() and recv() are linked. */
+#pragma comment( lib, "ws2_32" )
+#endif
 
 #define get_buf(v_buf, v_pos) (char *) Caml_ba_data_val(v_buf) + Long_val(v_pos)
 

--- a/bigstring-io-lib/src/bigstring_io_stubs.c
+++ b/bigstring-io-lib/src/bigstring_io_stubs.c
@@ -41,20 +41,20 @@ CAMLprim value shexp_bigstring_io_read(value fd, value buf, value ofs, value len
   CAMLparam1(buf);
   DWORD numread;
   DWORD err = 0;
-  char* buf = get_buf(buf, ofs);
+  char* ptr = get_buf(buf, ofs);
 
   if (Descr_kind_val(fd) == KIND_SOCKET) {
     int ret;
     SOCKET s = Socket_val(fd);
     caml_enter_blocking_section();
-    ret = recv(s, buf, Long_val(len), 0);
+    ret = recv(s, ptr, Long_val(len), 0);
     if (ret == SOCKET_ERROR) err = WSAGetLastError();
     caml_leave_blocking_section();
     numread = ret;
   } else {
     HANDLE h = Handle_val(fd);
     caml_enter_blocking_section();
-    if (! ReadFile(h, buf, Long_val(len), &numread, NULL))
+    if (! ReadFile(h, ptr, Long_val(len), &numread, NULL))
       err = GetLastError();
     caml_leave_blocking_section();
   }
@@ -71,20 +71,20 @@ CAMLprim value shexp_bigstring_io_write(value fd, value buf, value ofs, value le
   CAMLparam1(buf);
   DWORD numwritten;
   DWORD err = 0;
-  char* buf = get_buf(buf, ofs);
+  char* ptr = get_buf(buf, ofs);
 
   if (Descr_kind_val(fd) == KIND_SOCKET) {
     int ret;
     SOCKET s = Socket_val(fd);
     caml_enter_blocking_section();
-    ret = send(s, buf, Long_val(len), 0);
+    ret = send(s, ptr, Long_val(len), 0);
     if (ret == SOCKET_ERROR) err = WSAGetLastError();
     caml_leave_blocking_section();
     numwritten = ret;
   } else {
     HANDLE h = Handle_val(fd);
     caml_enter_blocking_section();
-    if (! WriteFile(h, src, Long_val(len), &numwritten, NULL))
+    if (! WriteFile(h, ptr, Long_val(len), &numwritten, NULL))
       err = GetLastError();
     caml_leave_blocking_section();
   }


### PR DESCRIPTION
Changes:

1. Fix MSVC runtime error:
    ```
    Fatal error: cannot load shared library dllshexp_bigstring_io_stubs
    Reason: Cannot resolve send
    ```
2. Fix MSVC compilation error:
    ```
    Local variable `char* buf` is overloaded with parameter `value buf`

    bigstring_io_stubs.c(44): error C2082: redefinition of formal parameter 'buf'
    bigstring_io_stubs.c(74): error C2082: redefinition of formal parameter 'buf'
    ```

3. Likely ancient refactor missed Windows code ... no `src` variable.

### Testing

```
$ opam exec --switch Y:\source\dksdk-type -- dune utop process-lib/src

────────────────────────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────                                                                                │ Welcome to utop version 2.13.1 (using OCaml version 4.14.0)! │                                                                                                                                                                └──────────────────────────────────────────────────────────────┘

Type #utop_help for help about using utop.

─( 19:41:45 )─< command 0 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # open Shexp_process;;
─( 19:41:45 )─< command 1 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # eval (run {|C:\Program Files\Git\cmd\git.exe|} ["status"]) ;;
On branch v0.16-msvc
Your branch is ahead of 'origin/v0.16-msvc' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
- : unit = ()
```
