### PR TITLE
Windows [find_executable] fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,6 @@
 - Add `Process.call_xxx` functions that are equivalent to their
   `Process.run_xxx` counterpart except that they take a single string
   list as argument (#8, David Chemouil)
+- Use `;` as PATH seperator on Windows. Find executables with `.exe`
+  extension on Windows. Workaround `Sys.file_exists` being true for
+  directories on Windows (#16, Jonah Beckford)


### PR DESCRIPTION
+ Use ';' as PATH seperator on Windows.

+ On Windows Sys.file_exists can return true even if Sys.is_directory is true. And an executable ends in `.exe`

### Before

```
utop # eval (find_executable_exn "git") ;;
Exception: Failure "command \"git\" not found".
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Shexp_process__Process.map.(fun) in file "process-lib/src/process.ml", line 533, characters 40-45
Called from Shexp_process__Process.exec in file "process-lib/src/process.ml", line 173, characters 12-47
Re-raised at Shexp_process__Process.exec in file "process-lib/src/process.ml", line 176, characters 8-19
Called from Stdlib__Fun.protect in file "fun.ml", line 33, characters 8-15
Re-raised at Stdlib__Fun.protect in file "fun.ml", line 38, characters 6-52
Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-153
```

And it has the same exception for `git.exe`.

### After

```
utop # let open Shexp_process in eval (find_executable "git" ) ;;
- : string option = Some "C:\\Program Files\\Git\\cmd\\git.exe"

utop # let open Shexp_process in eval (find_executable "git.exe" ) ;;
- : string option = Some "C:\\Program Files\\Git\\cmd\\git.exe"
```